### PR TITLE
Ensure energy created during bulk accel count save

### DIFF
--- a/api/lib/db/models/AccelCount.ts
+++ b/api/lib/db/models/AccelCount.ts
@@ -88,6 +88,14 @@ const Model = {
 
     const user = await UserModel.get(userId)
     if (user) {
+      const countsForEnergy = rows.filter((row) => row.hr > 0)
+
+      await Promise.all(
+        countsForEnergy.map((row) =>
+          saveEnergyFromCount(user, row as unknown as AccelCount)
+        )
+      )
+
       await createBoutsFromBatch(user, rows)
     }
 


### PR DESCRIPTION
## Summary
- ensure bulk accel count uploads persist energy records for counts with heart rate data
- reuse existing saveEnergyFromCount helper while preserving bout batch processing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6900d121c86c8329b2426ec256ae6256